### PR TITLE
Include Project Goals & Statement in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # aplcms-minus
+
+### You can find the live site for this project [here](https://library.austintexas.gov/meeting-rooms)
+
+## Project Summary & Goals
+
+1. Make the “room booking” user experience clearer and easier-to-complete
+2. Develop the room booking product in a robust and scalable way
+
+## The room booking work is Open Austin’s pilot of a multi-year partnership to:
+
+- Develop solid product foundations across the entire library website: robust code and docs, including explanations and how-to's for technical/nontechnical audiences.
+
+- Be as easy as possible for staff to tackle/implement.
+
+- Pass a11y (accessibility/ARIA) criteria.
+
+- Be open and available for community members, aka non staffers, to tackle/contribute with minimal staff oversight.


### PR DESCRIPTION
Add the overview for the project from the APL Onboarding document into the README.md file; I did this so that it will be more readily available while working on any new features.